### PR TITLE
Release main/Smdn.Net.SkStackIP-1.2.0

### DIFF
--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.1.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.2.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+b1231cf0cca65506f3356620e16e3ecd4cb811c1
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+0e506f4265dfd6eb80e5f98b4486e10a5cda9d99
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -137,7 +137,12 @@ namespace Smdn.Net.SkStackIP {
     public TimeSpan ReceiveUdpPollingInterval { get; set; }
     public ISynchronizeInvoke? SynchronizingObject { get; set; }
 
+    public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
     public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackPanDescription pan, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, int channelNumber, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
@@ -181,8 +186,10 @@ namespace Smdn.Net.SkStackIP {
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPort port, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPAddress destinationAddress, int destinationPort, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETPWDAsync(Action<IBufferWriter<byte>> writePassword, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<byte> password, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<char> password, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETRBIDAsync(Action<IBufferWriter<byte>> writeRBID, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<byte> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<char> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse<TValue>> SendSKSREGAsync<TValue>(SkStackRegister.RegisterEntry<TValue> register, CancellationToken cancellationToken = default) {}

--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.1.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.2.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+b1231cf0cca65506f3356620e16e3ecd4cb811c1
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+0e506f4265dfd6eb80e5f98b4486e10a5cda9d99
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -135,7 +135,12 @@ namespace Smdn.Net.SkStackIP {
     public TimeSpan ReceiveUdpPollingInterval { get; set; }
     public ISynchronizeInvoke? SynchronizingObject { get; set; }
 
+    public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
     public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackPanDescription pan, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, int channelNumber, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
@@ -179,8 +184,10 @@ namespace Smdn.Net.SkStackIP {
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPort port, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPAddress destinationAddress, int destinationPort, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETPWDAsync(Action<IBufferWriter<byte>> writePassword, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<byte> password, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<char> password, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETRBIDAsync(Action<IBufferWriter<byte>> writeRBID, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<byte> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<char> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse<TValue>> SendSKSREGAsync<TValue>(SkStackRegister.RegisterEntry<TValue> register, CancellationToken cancellationToken = default) {}

--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.1.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.2.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+b1231cf0cca65506f3356620e16e3ecd4cb811c1
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+0e506f4265dfd6eb80e5f98b4486e10a5cda9d99
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -128,7 +128,12 @@ namespace Smdn.Net.SkStackIP {
     public TimeSpan ReceiveUdpPollingInterval { get; set; }
     public ISynchronizeInvoke? SynchronizingObject { get; set; }
 
+    public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
     public ValueTask<IReadOnlyList<SkStackPanDescription>> ActiveScanAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackActiveScanOptions? scanOptions = null, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(Action<IBufferWriter<byte>> writeRBID, Action<IBufferWriter<byte>> writePassword, SkStackPanDescription pan, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, IPAddress paaAddress, int channelNumber, int panId, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackPanaSessionInfo> AuthenticateAsPanaClientAsync(ReadOnlyMemory<byte> rbid, ReadOnlyMemory<byte> password, PhysicalAddress paaMacAddress, SkStackChannel channel, int panId, CancellationToken cancellationToken = default) {}
@@ -172,8 +177,10 @@ namespace Smdn.Net.SkStackIP {
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPort port, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPAddress destinationAddress, int destinationPort, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
     public ValueTask<(SkStackResponse Response, bool IsCompletedSuccessfully)> SendSKSENDTOAsync(SkStackUdpPortHandle handle, IPEndPoint destination, ReadOnlyMemory<byte> data, SkStackUdpEncryption encryption = SkStackUdpEncryption.EncryptIfAble, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETPWDAsync(Action<IBufferWriter<byte>> writePassword, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<byte> password, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETPWDAsync(ReadOnlyMemory<char> password, CancellationToken cancellationToken = default) {}
+    public ValueTask<SkStackResponse> SendSKSETRBIDAsync(Action<IBufferWriter<byte>> writeRBID, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<byte> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse> SendSKSETRBIDAsync(ReadOnlyMemory<char> id, CancellationToken cancellationToken = default) {}
     public ValueTask<SkStackResponse<TValue>> SendSKSREGAsync<TValue>(SkStackRegister.RegisterEntry<TValue> register, CancellationToken cancellationToken = default) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #5](https://github.com/smdn/Smdn.Net.SkStackIP/actions/runs/9732056460).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.SkStackIP-1.2.0`
- package_prevver_ref: `releases/Smdn.Net.SkStackIP-1.1.0`
- package_prevver_tag: `releases/Smdn.Net.SkStackIP-1.1.0`
- package_id: `Smdn.Net.SkStackIP`
- package_id_with_version: `Smdn.Net.SkStackIP-1.2.0`
- package_version: `1.2.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.SkStackIP-1.2.0-1719751221`
- release_tag: `releases/Smdn.Net.SkStackIP-1.2.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/2a2658204b2349b126e3df3ae40d9caa`](https://gist.github.com/smdn/2a2658204b2349b126e3df3ae40d9caa)
- artifact_name_nupkg: `Smdn.Net.SkStackIP.1.2.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.SkStackIP.latest.nuspec
+++ Smdn.Net.SkStackIP.1.2.0.nuspec
@@ -1,43 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.SkStackIP</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Smdn.Net.SkStackIP</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.SkStackIP.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.SkStackIP</projectUrl>
     <description>Provides APIs for operating devices that implement Skyley Networks' SKSTACK IP.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.1.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.2.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp SKSTACK,SKSTACK-IP,PANA,Route-B,ECHONET,ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" branch="main" commit="b1231cf0cca65506f3356620e16e3ecd4cb811c1" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" commit="0e506f4265dfd6eb80e5f98b4486e10a5cda9d99" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net6.0/Smdn.Net.SkStackIP.dll" target="lib/net6.0/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net6.0/Smdn.Net.SkStackIP.xml" target="lib/net6.0/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.dll" target="lib/net8.0/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.xml" target="lib/net8.0/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.dll" target="lib/netstandard2.1/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.xml" target="lib/netstandard2.1/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.SkStackIP.png" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

