### PR TITLE
Release main/Smdn.Net.SkStackIP-1.4.0

### DIFF
--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.3.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.4.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.3.0.0
-//   InformationalVersion: 1.3.0+7931ab6db93341f49b92e060d48f76286ce36ded
+//   AssemblyVersion: 1.4.0.0
+//   InformationalVersion: 1.4.0+0042217f1f00329fae1eb89b19f6739d41ff5b21
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -115,6 +115,7 @@ namespace Smdn.Net.SkStackIP {
     protected SkStackActiveScanOptions() {}
 
     public abstract SkStackActiveScanOptions Clone();
+    public IEnumerable<int> EnumerateScanDurationFactors() {}
     object ICloneable.Clone() {}
   }
 

--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.3.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.4.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.3.0.0
-//   InformationalVersion: 1.3.0+7931ab6db93341f49b92e060d48f76286ce36ded
+//   AssemblyVersion: 1.4.0.0
+//   InformationalVersion: 1.4.0+0042217f1f00329fae1eb89b19f6739d41ff5b21
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -113,6 +113,7 @@ namespace Smdn.Net.SkStackIP {
     protected SkStackActiveScanOptions() {}
 
     public abstract SkStackActiveScanOptions Clone();
+    public IEnumerable<int> EnumerateScanDurationFactors() {}
     object ICloneable.Clone() {}
   }
 

--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.3.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.4.0)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.3.0.0
-//   InformationalVersion: 1.3.0+7931ab6db93341f49b92e060d48f76286ce36ded
+//   AssemblyVersion: 1.4.0.0
+//   InformationalVersion: 1.4.0+0042217f1f00329fae1eb89b19f6739d41ff5b21
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -107,6 +107,7 @@ namespace Smdn.Net.SkStackIP {
     protected SkStackActiveScanOptions() {}
 
     public abstract SkStackActiveScanOptions Clone();
+    public IEnumerable<int> EnumerateScanDurationFactors() {}
     object ICloneable.Clone() {}
   }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #8](https://github.com/smdn/Smdn.Net.SkStackIP/actions/runs/11642790441).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.SkStackIP-1.4.0`
- package_prevver_ref: `releases/Smdn.Net.SkStackIP-1.3.0`
- package_prevver_tag: `releases/Smdn.Net.SkStackIP-1.3.0`
- package_id: `Smdn.Net.SkStackIP`
- package_id_with_version: `Smdn.Net.SkStackIP-1.4.0`
- package_version: `1.4.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.SkStackIP-1.4.0-1730551413`
- release_tag: `releases/Smdn.Net.SkStackIP-1.4.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/493e76d259d9b491adfec51e69646903`](https://gist.github.com/smdn/493e76d259d9b491adfec51e69646903)
- artifact_name_nupkg: `Smdn.Net.SkStackIP.1.4.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.SkStackIP.latest.nuspec
+++ Smdn.Net.SkStackIP.1.4.0.nuspec
@@ -1,43 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.SkStackIP</id>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <title>Smdn.Net.SkStackIP</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.SkStackIP.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.SkStackIP</projectUrl>
     <description>Provides APIs for operating devices that implement Skyley Networks' SKSTACK IP.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.3.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.4.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp SKSTACK,SKSTACK-IP,PANA,Route-B,ECHONET,ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" branch="main" commit="7931ab6db93341f49b92e060d48f76286ce36ded" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" commit="0042217f1f00329fae1eb89b19f6739d41ff5b21" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net6.0/Smdn.Net.SkStackIP.dll" target="lib/net6.0/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net6.0/Smdn.Net.SkStackIP.xml" target="lib/net6.0/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.dll" target="lib/net8.0/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.xml" target="lib/net8.0/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.dll" target="lib/netstandard2.1/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.xml" target="lib/netstandard2.1/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.SkStackIP.png" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

