### PR TITLE
Release main/Smdn.Devices.BP35XX-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.0.0)
+// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.1.0)
 //   Name: Smdn.Devices.BP35XX
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+ef185af5c73268aab02d6909202fffce4560122b
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+fc01bab8c6330c41db1ce6309f8f5f79b42b2785
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -87,6 +87,12 @@ namespace Smdn.Devices.BP35XX {
     public ValueTask SetUartOptionsAsync(BP35UartBaudRate baudRate, BP35UartCharacterInterval characterInterval = BP35UartCharacterInterval.None, BP35UartFlowControl flowControl = BP35UartFlowControl.Disabled, CancellationToken cancellationToken = default) {}
     public ValueTask SetUartOptionsAsync(BP35UartConfigurations uartConfigurations, CancellationToken cancellationToken = default) {}
     public ValueTask SetUdpDataFormatAsync(BP35UdpReceiveDataFormat format, CancellationToken cancellationToken = default) {}
+  }
+
+  public class BP35SerialPortException : IOException {
+    public BP35SerialPortException() {}
+    public BP35SerialPortException(string message) {}
+    public BP35SerialPortException(string message, Exception? innerException = null) {}
   }
 
   public readonly struct BP35UartConfigurations {

--- a/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.0.0)
+// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.1.0)
 //   Name: Smdn.Devices.BP35XX
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+ef185af5c73268aab02d6909202fffce4560122b
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+fc01bab8c6330c41db1ce6309f8f5f79b42b2785
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -87,6 +87,12 @@ namespace Smdn.Devices.BP35XX {
     public ValueTask SetUartOptionsAsync(BP35UartBaudRate baudRate, BP35UartCharacterInterval characterInterval = BP35UartCharacterInterval.None, BP35UartFlowControl flowControl = BP35UartFlowControl.Disabled, CancellationToken cancellationToken = default) {}
     public ValueTask SetUartOptionsAsync(BP35UartConfigurations uartConfigurations, CancellationToken cancellationToken = default) {}
     public ValueTask SetUdpDataFormatAsync(BP35UdpReceiveDataFormat format, CancellationToken cancellationToken = default) {}
+  }
+
+  public class BP35SerialPortException : IOException {
+    public BP35SerialPortException() {}
+    public BP35SerialPortException(string message) {}
+    public BP35SerialPortException(string message, Exception? innerException = null) {}
   }
 
   public readonly struct BP35UartConfigurations {

--- a/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Devices.BP35XX/Smdn.Devices.BP35XX-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.0.0)
+// Smdn.Devices.BP35XX.dll (Smdn.Devices.BP35XX-2.1.0)
 //   Name: Smdn.Devices.BP35XX
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+ef185af5c73268aab02d6909202fffce4560122b
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+fc01bab8c6330c41db1ce6309f8f5f79b42b2785
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -83,6 +83,12 @@ namespace Smdn.Devices.BP35XX {
     public ValueTask SetUartOptionsAsync(BP35UartBaudRate baudRate, BP35UartCharacterInterval characterInterval = BP35UartCharacterInterval.None, BP35UartFlowControl flowControl = BP35UartFlowControl.Disabled, CancellationToken cancellationToken = default) {}
     public ValueTask SetUartOptionsAsync(BP35UartConfigurations uartConfigurations, CancellationToken cancellationToken = default) {}
     public ValueTask SetUdpDataFormatAsync(BP35UdpReceiveDataFormat format, CancellationToken cancellationToken = default) {}
+  }
+
+  public class BP35SerialPortException : IOException {
+    public BP35SerialPortException() {}
+    public BP35SerialPortException(string message) {}
+    public BP35SerialPortException(string message, Exception? innerException = null) {}
   }
 
   public readonly struct BP35UartConfigurations {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #9](https://github.com/smdn/Smdn.Net.SkStackIP/actions/runs/11839365887).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.BP35XX-2.1.0`
- package_prevver_ref: `releases/Smdn.Devices.BP35XX-2.0.0`
- package_prevver_tag: `releases/Smdn.Devices.BP35XX-2.0.0`
- package_id: `Smdn.Devices.BP35XX`
- package_id_with_version: `Smdn.Devices.BP35XX-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.BP35XX-2.1.0-1731595028`
- release_tag: `releases/Smdn.Devices.BP35XX-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/f25f7060c1d1309c1e9c4cd77eaad40a`](https://gist.github.com/smdn/f25f7060c1d1309c1e9c4cd77eaad40a)
- artifact_name_nupkg: `Smdn.Devices.BP35XX.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Devices.BP35XX.latest.nuspec
+++ Smdn.Devices.BP35XX.2.1.0.nuspec
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Devices.BP35XX</id>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <title>Smdn.Devices.BP35XX</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Devices.BP35XX.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.SkStackIP</projectUrl>
     <description>Provides APIs to operate ROHM BP35A1 and other ROHM Wi-SUN modules using the SKSTACK-IP command.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Devices.BP35XX-2.0.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Devices.BP35XX-2.1.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp SKSTACK,SKSTACK-IP,BP35A1,ROHM-BP35A1,Wi-SUN</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" branch="main" commit="ef185af5c73268aab02d6909202fffce4560122b" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" commit="fc01bab8c6330c41db1ce6309f8f5f79b42b2785" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Smdn.Net.SkStackIP" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Ports" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Smdn.Net.SkStackIP" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Ports" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Smdn.Net.SkStackIP" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Ports" version="8.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/net6.0/Smdn.Devices.BP35XX.dll" target="lib/net6.0/Smdn.Devices.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/net6.0/Smdn.Devices.BP35XX.xml" target="lib/net6.0/Smdn.Devices.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/net8.0/Smdn.Devices.BP35XX.dll" target="lib/net8.0/Smdn.Devices.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/net8.0/Smdn.Devices.BP35XX.xml" target="lib/net8.0/Smdn.Devices.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/netstandard2.1/Smdn.Devices.BP35XX.dll" target="lib/netstandard2.1/Smdn.Devices.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/netstandard2.1/Smdn.Devices.BP35XX.xml" target="lib/netstandard2.1/Smdn.Devices.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Devices.BP35XX.png" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Devices.BP35XX/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

