### PR TITLE
Release main/Smdn.Net.SkStackIP-1.5.1

### DIFF
--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.5.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.5.1)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.5.0.0
-//   InformationalVersion: 1.5.0+631c22046275c09f042cc7f5d6d1e8d6af6500d7
+//   AssemblyVersion: 1.5.1.0
+//   InformationalVersion: 1.5.1+4e659267f00877b910ce282f3bebfb7dcb3e61a9
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -215,6 +215,7 @@ namespace Smdn.Net.SkStackIP {
     [MemberNotNull("PanaSessionPeerAddress")]
     [Obsolete("Use ThrowIfPanaSessionNotEstablished instead.")]
     internal protected void ThrowIfPanaSessionIsNotEstablished() {}
+    [MemberNotNull("PanaSessionPeerAddress")]
     public void ThrowIfPanaSessionNotAlive() {}
     [MemberNotNull("PanaSessionPeerAddress")]
     public void ThrowIfPanaSessionNotEstablished() {}

--- a/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.5.0)
+// Smdn.Net.SkStackIP.dll (Smdn.Net.SkStackIP-1.5.1)
 //   Name: Smdn.Net.SkStackIP
-//   AssemblyVersion: 1.5.0.0
-//   InformationalVersion: 1.5.0+631c22046275c09f042cc7f5d6d1e8d6af6500d7
+//   AssemblyVersion: 1.5.1.0
+//   InformationalVersion: 1.5.1+4e659267f00877b910ce282f3bebfb7dcb3e61a9
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #13](https://github.com/smdn/Smdn.Net.SkStackIP/actions/runs/15795147626).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.SkStackIP-1.5.1`
- package_prevver_ref: `releases/Smdn.Net.SkStackIP-1.5.0`
- package_prevver_tag: `releases/Smdn.Net.SkStackIP-1.5.0`
- package_id: `Smdn.Net.SkStackIP`
- package_id_with_version: `Smdn.Net.SkStackIP-1.5.1`
- package_version: `1.5.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.SkStackIP-1.5.1-1750504507`
- release_tag: `releases/Smdn.Net.SkStackIP-1.5.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/6f0eb3c14afa4cfa98fbf9a6af77e919`](https://gist.github.com/smdn/6f0eb3c14afa4cfa98fbf9a6af77e919)
- artifact_name_nupkg: `Smdn.Net.SkStackIP.1.5.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.SkStackIP.latest.nuspec
+++ Smdn.Net.SkStackIP.1.5.1.nuspec
@@ -1,36 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.SkStackIP</id>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <title>Smdn.Net.SkStackIP</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.SkStackIP.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.SkStackIP</projectUrl>
     <description>Provides APIs for operating devices that implement Skyley Networks' SKSTACK IP.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.5.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.SkStackIP/releases/tag/releases%2FSmdn.Net.SkStackIP-1.5.1</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp SKSTACK,SKSTACK-IP,PANA,Route-B,ECHONET,ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" branch="main" commit="631c22046275c09f042cc7f5d6d1e8d6af6500d7" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.SkStackIP" commit="4e659267f00877b910ce282f3bebfb7dcb3e61a9" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.ControlPicture" version="[3.0.0.1, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.dll" target="lib/net8.0/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/net8.0/Smdn.Net.SkStackIP.xml" target="lib/net8.0/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.dll" target="lib/netstandard2.1/Smdn.Net.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.SkStackIP.xml" target="lib/netstandard2.1/Smdn.Net.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.SkStackIP.png" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Net.SkStackIP/Smdn.Net.SkStackIP/src/Smdn.Net.SkStackIP/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

